### PR TITLE
civ menu, or any scripts used previously did not have a guarenteed se…

### DIFF
--- a/init.sqf
+++ b/init.sqf
@@ -23,7 +23,8 @@ execVM "briefing.sqf";
 waitUntil { (((time > 1) && (alive player)) || (isServer)) };
 
 // Island Life Initialization
-execVM "core\init.sqf";
+_h = execVM "core\init.sqf";
+waitUntil{scriptDone _h};
 
 //Other Initializations
 call compile preProcessFile "Scripts\triggers.sqf";


### PR DESCRIPTION
…t values from "core". This means scripts that needed things like isciv, could throw an error, as execVM will run a script in parallel with other scripts.

Added a waitUntil before running later scripts.